### PR TITLE
Add PHP Version of top_k Function for PHPMath and LinearAlgebra

### DIFF
--- a/src/Drivers/MatlibPHP/PhpMath.php
+++ b/src/Drivers/MatlibPHP/PhpMath.php
@@ -1423,7 +1423,6 @@ class PhpMath
         int $n,
         Buffer $A, int $offsetA, int $ldA,
         int $k,
-        bool $sorted,
         Buffer $topValues, int $offsetTopValues,
         Buffer $topIndices, int $offsetTopIndices
     ): void {
@@ -1442,10 +1441,6 @@ class PhpMath
             usort($valueIndexPairs, fn($a, $b) => $b['value'] <=> $a['value']);
 
             $topKPairs = array_slice($valueIndexPairs, 0, $k);
-
-            if ($sorted) {
-                usort($topKPairs, fn($a, $b) => $b['value'] <=> $a['value']);
-            }
 
             for ($j = 0; $j < $k; $j++) {
                 $topValues[$offsetTopValues + $i * $k + $j] = $topKPairs[$j]['value'];

--- a/src/Drivers/MatlibPHP/PhpMath.php
+++ b/src/Drivers/MatlibPHP/PhpMath.php
@@ -1418,6 +1418,43 @@ class PhpMath
         }
     }
 
+    public function top_k(
+        int $m,
+        int $n,
+        Buffer $A, int $offsetA, int $ldA,
+        int $k,
+        bool $sorted,
+        Buffer $topValues, int $offsetTopValues,
+        Buffer $topIndices, int $offsetTopIndices
+    ): void {
+        if ($offsetA + ($m - 1) * $ldA + ($n - 1) >= count($A)) {
+            throw new InvalidArgumentException('Vector specification too large for buffer.');
+        }
+
+        for ($i = 0; $i < $m; $i++) {
+            $idA = $offsetA + $i * $ldA;
+
+            $valueIndexPairs = [];
+            for ($j = 0; $j < $n; $j++) {
+                $valueIndexPairs[] = ['value' => $A[$idA + $j], 'index' => $j];
+            }
+
+            usort($valueIndexPairs, fn($a, $b) => $b['value'] <=> $a['value']);
+
+            $topKPairs = array_slice($valueIndexPairs, 0, $k);
+
+            if ($sorted) {
+                usort($topKPairs, fn($a, $b) => $b['value'] <=> $a['value']);
+            }
+
+            for ($j = 0; $j < $k; $j++) {
+                $topValues[$offsetTopValues + $i * $k + $j] = $topKPairs[$j]['value'];
+                $topIndices[$offsetTopIndices + $i * $k + $j] = $topKPairs[$j]['index'];
+            }
+        }
+    }
+
+
     public function astype(
         int $n,
         int $dtype,

--- a/src/LinearAlgebra.php
+++ b/src/LinearAlgebra.php
@@ -2542,6 +2542,48 @@ class LinearAlgebra
     }
 
     /**
+     *  X := (top_values, top_indices) = top_k(X,k,sorted=true)
+     * @return NDArray[]
+     */
+    public function top_k(
+        NDArray $X,
+        int $k,
+        bool $sorted=false,
+    ) : array
+    {
+        // Check that the input array is 2-dimensional
+        if ($X->ndim() !== 2) {
+            throw new InvalidArgumentException('"X" must be 2-D dimension');
+        }
+
+
+        [$m, $n] = $X->shape();
+        $XX = $X->buffer();
+        $offX = $X->offset();
+        $ldA = $n;
+
+        $topValues = $this->alloc([$m, $k], dtype: $X->dtype());
+        $topIndices = $this->alloc([$m, $k], dtype: NDArray::int32);
+
+        $buffTV = $topValues->buffer();
+        $offTV = $topValues->offset();
+        $buffTI = $topIndices->buffer();
+        $offTI = $topIndices->offset();
+
+        // Call the underlying top_k function
+        $this->math->top_k(
+            $m, $n,
+            $XX, $offX,
+            $ldA,
+            $k, $sorted,
+            $buffTV, $offTV,
+            $buffTI, $offTI
+        );
+
+        return [$topValues, $topIndices];
+    }
+
+    /**
      *    X(m) := sum( A(m,n) )
      */
     public function reduceSum( // reduceSumEx
@@ -3840,7 +3882,7 @@ class LinearAlgebra
                     //if($perm!=[1,0]) {
                     //    throw new InvalidArgumentException('unmatch sourceshape and perm');
                     //}
-                    
+
                 }
             }
             return $this->transpose2D($A,$B);

--- a/src/LinearAlgebra.php
+++ b/src/LinearAlgebra.php
@@ -2548,7 +2548,6 @@ class LinearAlgebra
     public function top_k(
         NDArray $X,
         int $k,
-        bool $sorted=false,
     ) : array
     {
         // Check that the input array is 2-dimensional
@@ -2574,8 +2573,7 @@ class LinearAlgebra
         $this->math->top_k(
             $m, $n,
             $XX, $offX,
-            $ldA,
-            $k, $sorted,
+            $ldA, $k,
             $buffTV, $offTV,
             $buffTI, $offTI
         );

--- a/tests/RindowTest/Math/Matrix/LinearAlgebraTest.php
+++ b/tests/RindowTest/Math/Matrix/LinearAlgebraTest.php
@@ -6191,9 +6191,8 @@ class LinearAlgebraTest extends TestCase
         ]);
 
         $k = 3;
-        $sorted = true;
 
-        [$topValues, $topIndices] = $la->top_k($x, $k, $sorted);
+        [$topValues, $topIndices] = $la->top_k($x, $k);
 
         $expectedTopValues = [
             [93, 69, 66],
@@ -6236,12 +6235,11 @@ class LinearAlgebraTest extends TestCase
         $rowsize = 64;
         $colsize = 100000;
         $k = 10;
-        $sorted = true;
 
         $x = $la->ones($la->alloc([$rowsize, $colsize], dtype: NDArray::float32));
 
         // Call the top_k function
-        [$topValues, $topIndices] = $la->top_k($x, $k, $sorted);
+        [$topValues, $topIndices] = $la->top_k($x, $k);
 
         $this->assertTrue($this->equalTest([$rowsize, $k], $topValues->shape()));
         $this->assertTrue($this->equalTest(NDArray::float32, $topValues->dtype()));
@@ -6253,11 +6251,10 @@ class LinearAlgebraTest extends TestCase
         $rowsize = 100000;
         $colsize = 64;
         $k = 5;
-        $sorted = true;
 
         $x = $la->ones($la->alloc([$rowsize, $colsize], dtype: NDArray::float32));
 
-        [$topValues, $topIndices] = $la->top_k($x, $k, $sorted);
+        [$topValues, $topIndices] = $la->top_k($x, $k);
 
         $this->assertTrue($this->equalTest([$rowsize, $k], $topValues->shape()));
         $this->assertTrue($this->equalTest(NDArray::float32, $topValues->dtype()));
@@ -6282,42 +6279,38 @@ class LinearAlgebraTest extends TestCase
         // Large size scenario 1
         $colsize = 100000;
         $rowsize = 64;
-        $k = 10; // Number of top elements to find
-        $sorted = true; // Return sorted results
+        $k = 10;
 
-        // Create a large matrix and fill it with ones
         $x = $la->alloc([$rowsize, $colsize], dtype: NDArray::float32);
         fwrite(STDERR, "fill-start\n");
         $la->fill(1.0, $x);
         fwrite(STDERR, "fill-end\n");
 
         fwrite(STDERR, "pre-start\n");
-        [$topValues, $topIndices] = $la->top_k($x, $k, $sorted);
+        [$topValues, $topIndices] = $la->top_k($x, $k);
         fwrite(STDERR, "pre-end\n");
 
         $start = hrtime(true);
-        [$topValues, $topIndices] = $la->top_k($x, $k, $sorted);
+        [$topValues, $topIndices] = $la->top_k($x, $k);
         $end = hrtime(true);
         echo "\n" . (explode(' ', $la->getConfig()))[0] . '=' . number_format($end - $start) . "\n";
 
         // Large size scenario 2
         $colsize = 64;
         $rowsize = 1000000;
-        $k = 5; // Number of top elements to find
-        $sorted = true; // Return sorted results
+        $k = 5;
 
-        // Create a large matrix and fill it with ones
         $x = $la->alloc([$rowsize, $colsize], dtype: NDArray::float32);
         fwrite(STDERR, "fill-start\n");
         $la->fill(1.0, $x);
         fwrite(STDERR, "fill-end\n");
 
         fwrite(STDERR, "pre-start\n");
-        [$topValues, $topIndices] = $la->top_k($x, $k, $sorted);
+        [$topValues, $topIndices] = $la->top_k($x, $k);
         fwrite(STDERR, "pre-end\n");
 
         $start = hrtime(true);
-        [$topValues, $topIndices] = $la->top_k($x, $k, $sorted);
+        [$topValues, $topIndices] = $la->top_k($x, $k);
         $end = hrtime(true);
         echo "\n" . (explode(' ', $la->getConfig()))[0] . '=' . number_format($end - $start) . "\n";
     }


### PR DESCRIPTION
This pull request adds the PHP implementation of the `top_k` function to the PHPMath library, aligning it with the C library implementation pending approval (see [C Library Implementation PR](https://github.com/rindow/rindow-matlib/pull/3)).

### Key Features:
- **top_k for PHPMath**: Provides the `top_k` function for the PHPMath library with similar functionality to the one in the C library.
- **Integration with LinearAlgebra**: Integrated the `top_k` function into the LinearAlgebra class, allowing seamless switching between math libraries (Matlib or PHPMath).
- **Compatibility**: Matches the behavior and signature of the C library implementation to ensure consistency across libraries.

Please review the implementation and let me know if there are any suggestions or concerns. Thank you!
